### PR TITLE
Develop

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,9 +12,6 @@
         "run",
         "dv"
       ],
-      "env": {
-        "PB_URL": "http://127.0.0.1:8080"
-      },
       "console": "integratedTerminal",
       "autoAttachChildProcesses": true,
       "skipFiles": [

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ LOG_LEVEL=info
 LOG_FORMAT=pretty
 LOG_COLOR=true
 
+# Session / auth
+# Max cookie age in seconds (default 48h)
+SESSION_MAX_AGE=172800
+
 # Apple Music API configuration
 SONG_CHOICE_VALIDATE=true
 APPLE_MUSIC_KEY_ID=
@@ -96,5 +100,6 @@ Change these credentials for real deployments.
 ## Notes on Configuration and Deployment
 - The compose file (`compose.yaml`) builds local images. For ready images use `compose.deploy.yaml` and set `DOCKERHUB_USERNAME` accordingly.
 - The app reads the backend URL via `PB_URL` (already set to `http://backend:8080` in compose).
+- Session cookies are limited by `SESSION_MAX_AGE` (default 48h). The server also validates
+  the auth token on each request and clears it if invalid (e.g. after DB reset).
 - Apple validation uses `APPLE_MUSIC_PRIVATE_KEY`. If unset, song validation is skipped gracefully even when `SONG_CHOICE_VALIDATE` is `true`.
-

--- a/app/src/hooks.server.test.ts
+++ b/app/src/hooks.server.test.ts
@@ -1,56 +1,77 @@
 import { describe, it, expect, vi } from 'vitest'
+import type { TypedPocketBase } from '$lib/pocketbase-types'
 // Mock PocketBase used in hooks so we can control auth via cookie
 vi.mock('pocketbase', () => {
   return {
-    default: function MockPB() {
-      const self: any = this
-      self.collection = vi.fn(() => ({}))
-      self.authStore = {
-        record: null as any,
+    default: function MockPB(this: {
+      collection: (name: string) => Record<string, unknown>
+      authStore: {
+        record: unknown
+        loadFromCookie: (cookie: string) => void
+        exportToCookie: () => string
+        clear: () => void
+        isValid?: boolean
+      }
+    }) {
+      this.collection = vi.fn(() => ({
+        authRefresh: vi.fn(async () => ({}))
+      }))
+      const authStore = {
+        record: null as unknown,
+        isValid: false,
         loadFromCookie: vi.fn((cookie: string) => {
           // allow tests to set role via a simple cookie string like "role=spectator; id=u1"
           const role = /role=([^;]+)/.exec(cookie || '')?.[1]
           const id = /id=([^;]+)/.exec(cookie || '')?.[1] || 'u1'
-          if (role) self.authStore.record = { id, role }
+          if (role) {
+            authStore.record = { id, role }
+            authStore.isValid = true
+          }
         }),
         exportToCookie: vi.fn(() => 'pb_auth=stub; Path=/; HttpOnly'),
         clear: vi.fn()
       }
+      this.authStore = authStore
     }
   }
 })
 import { handle as hookHandle } from './hooks.server'
-import { makeURL } from './test/mocks'
+import { createPBMock, makeURL } from './test/mocks'
 
-function makeEvent(pathname: string, cookie = '') {
+type HookArg = Parameters<typeof hookHandle>[0]
+type HookEvent = HookArg['event']
+type HookResolve = HookArg['resolve']
+
+function makeEvent(pathname: string, cookie = ''): HookEvent {
   const url = makeURL(pathname)
-  const req = new Request(url, { headers: cookie ? { cookie } : {} as any })
+  const headers: HeadersInit | undefined = cookie ? { cookie } : undefined
+  const request = new Request(url, headers ? { headers } : undefined)
   return {
-    request: req,
+    request,
     url,
-    locals: { pb: null as any, user: null },
+    locals: { pb: createPBMock() as unknown as TypedPocketBase, user: null },
     cookies: { get: () => null, set: () => {}, delete: () => {} }
-  }
+  } as unknown as HookEvent
 }
 
 describe('hooks.server route guard', () => {
   it('redirects unauthenticated to /auth', async () => {
     const event = makeEvent('/rating')
-    const resolve = () => Promise.resolve(new Response('ok'))
+    const resolve: HookResolve = () => Promise.resolve(new Response('ok'))
     // pb has no auth record => unauthenticated
     await expect(hookHandle({ event, resolve })).rejects.toMatchObject({ status: 303 })
   })
 
   it('redirects logged-in users away from /auth', async () => {
     const event = makeEvent('/auth', 'role=spectator; id=u1')
-    const resolve = () => Promise.resolve(new Response('ok'))
+    const resolve: HookResolve = () => Promise.resolve(new Response('ok'))
     await expect(hookHandle({ event, resolve })).rejects.toMatchObject({ status: 303 })
   })
 
   it('allows participant on /song-choice and denies /rating', async () => {
     // Allowed route
     const event1 = makeEvent('/song-choice', 'role=participant; id=u2')
-    const resolve = () => Promise.resolve(new Response('ok'))
+    const resolve: HookResolve = () => Promise.resolve(new Response('ok'))
     const resp = await hookHandle({ event: event1, resolve })
     expect(resp.status).toBe(200)
 
@@ -60,7 +81,7 @@ describe('hooks.server route guard', () => {
   })
 
   it('allows spectator on /rating and denies /song-choice', async () => {
-    const resolve = () => Promise.resolve(new Response('ok'))
+    const resolve: HookResolve = () => Promise.resolve(new Response('ok'))
 
     const event1 = makeEvent('/rating', 'role=spectator; id=u3')
     const resp = await hookHandle({ event: event1, resolve })
@@ -71,9 +92,20 @@ describe('hooks.server route guard', () => {
   })
 
   it('allows admin on /admin', async () => {
-    const resolve = () => Promise.resolve(new Response('ok'))
+    const resolve: HookResolve = () => Promise.resolve(new Response('ok'))
     const event = makeEvent('/admin', 'role=admin; id=admin1')
     const resp = await hookHandle({ event, resolve })
     expect(resp.status).toBe(200)
+  })
+})
+
+describe('hooks.server cookie sync', () => {
+  it('appends set-cookie header via exportToCookie', async () => {
+    const event = makeEvent('/song-choice', 'role=participant; id=u9')
+    const resolve: HookResolve = () => Promise.resolve(new Response('ok'))
+    const resp = await hookHandle({ event, resolve })
+    expect(resp.status).toBe(200)
+    // Our PocketBase mock returns this fixed cookie string
+    expect(resp.headers.get('set-cookie')).toBe('pb_auth=stub; Path=/; HttpOnly')
   })
 })

--- a/app/src/lib/server/bootstrap.ts
+++ b/app/src/lib/server/bootstrap.ts
@@ -101,7 +101,7 @@ export function initBootstrap() {
   // Retry up to ~100s while PocketBase may still be starting
   const maxRetries = 100
   const delayMs = 1000
-
+  
   logger.info('Bootstrap: init start', { baseUrl: BASE_URL, maxRetries, delayMs })
 
   const attempt = async (n: number) => {

--- a/app/src/routes/auth/+page.svelte
+++ b/app/src/routes/auth/+page.svelte
@@ -88,8 +88,11 @@
 		}
 		if (typeof window !== 'undefined') {
 			const q = new URLSearchParams(window.location.search)
-			if (q.get('reason') === 'auth_required') {
+			const reason = q.get('reason')
+			if (reason === 'auth_required') {
 				banner = 'Bitte melde dich an, um fortzufahren.'
+			} else if (reason === 'account_deleted') {
+				banner = 'Dein Konto wurde gelöscht. Du kannst dich neu registrieren.'
 			}
 			next = q.get('next') ?? ''
 		}

--- a/app/src/routes/auth/server.test.ts
+++ b/app/src/routes/auth/server.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest'
+import { actions } from './+page.server'
+import { createPBMock } from '../../test/mocks'
+import type { TypedPocketBase } from '$lib/pocketbase-types'
+
+function reqOf(fields: Record<string, unknown>): Request {
+  const request = {
+    formData: async () => ({
+      get: (k: string) => (k in fields ? (fields as Record<string, unknown>)[k] ?? null : null) as unknown as FormDataEntryValue | null
+    } as Pick<FormData, 'get'>)
+  }
+  return request as unknown as Request
+}
+
+describe('auth actions', () => {
+  it('login validates missing fields', async () => {
+    const event = {
+      request: reqOf({ email: '', password: '' }),
+      locals: { pb: createPBMock() as unknown as TypedPocketBase }
+    } as unknown as Parameters<typeof actions.login>[0]
+
+    const res = (await actions.login(event)) as unknown
+    const failRes = res as { status: number; data?: { message?: string } }
+    expect(failRes.status).toBe(400)
+    expect(failRes.data?.message).toBe('Bitte E-Mail und Passwort angeben.')
+  })
+
+  it('login authenticates and redirects', async () => {
+    const authWithPassword = vi.fn(async () => ({}))
+    const pb = createPBMock({ users: { authWithPassword } })
+
+    const event = {
+      request: reqOf({ email: 'e@x.com', password: 'pass', next: '/profile' }),
+      locals: { pb: pb as unknown as TypedPocketBase }
+    } as unknown as Parameters<typeof actions.login>[0]
+
+    await expect(actions.login(event)).rejects.toMatchObject({ status: 303, location: '/profile' })
+    expect(authWithPassword).toHaveBeenCalledWith('e@x.com', 'pass')
+  })
+
+  it('signup validates required fields', async () => {
+    const event = {
+      request: reqOf({ email: '', password: '', passwordConfirm: '', firstName: '', lastName: '', artistName: '' }),
+      locals: { pb: createPBMock() as unknown as TypedPocketBase, user: null }
+    } as unknown as Parameters<typeof actions.signup>[0]
+
+    const res = (await actions.signup(event)) as unknown
+    const failRes = res as { status: number; data?: { message?: string } }
+    expect(failRes.status).toBe(400)
+    expect(failRes.data?.message).toBe('Bitte alle Felder ausfüllen.')
+  })
+
+  it('signup validates password confirmation', async () => {
+    const event = {
+      request: reqOf({
+        email: 'e@x.com', password: 'a', passwordConfirm: 'b', firstName: 'F', lastName: 'L', artistName: 'A'
+      }),
+      locals: { pb: createPBMock() as unknown as TypedPocketBase, user: null }
+    } as unknown as Parameters<typeof actions.signup>[0]
+
+    const res = (await actions.signup(event)) as unknown
+    const failRes = res as { status: number; data?: { message?: string } }
+    expect(failRes.status).toBe(400)
+    expect(failRes.data?.message).toBe('Passwörter stimmen nicht überein.')
+  })
+
+  it('signup creates user, logs in and redirects', async () => {
+    const create = vi.fn(async (data: Record<string, unknown>) => ({ id: 'new-user', ...data }))
+    const authWithPassword = vi.fn(async () => ({}))
+    const pb = createPBMock({ users: { create, authWithPassword } })
+
+    const event = {
+      request: reqOf({
+        email: 'e@x.com', password: 'pass', passwordConfirm: 'pass', firstName: 'F', lastName: 'L', artistName: 'A', next: '/'
+      }),
+      locals: { pb: pb as unknown as TypedPocketBase, user: null }
+    } as unknown as Parameters<typeof actions.signup>[0]
+
+    await expect(actions.signup(event)).rejects.toMatchObject({ status: 303, location: '/' })
+    expect(create).toHaveBeenCalled()
+    expect(authWithPassword).toHaveBeenCalledWith('e@x.com', 'pass')
+  })
+
+  it('logout clears auth and redirects', async () => {
+    const pb = createPBMock()
+
+    const event = {
+      locals: { pb: pb as unknown as TypedPocketBase }
+    } as unknown as Parameters<typeof actions.logout>[0]
+
+    await expect(actions.logout(event)).rejects.toMatchObject({ status: 303, location: '/auth' })
+    expect(pb.authStore.clear).toHaveBeenCalled()
+  })
+})

--- a/app/src/routes/layout.server.test.ts
+++ b/app/src/routes/layout.server.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { load as layoutLoad } from './+layout.server'
+import { createPBMock, makeURL, makeUser } from '../test/mocks'
+import type { TypedPocketBase, UsersResponse } from '$lib/pocketbase-types'
+
+describe('+layout.server guard', () => {
+  it('redirects unauthenticated to /auth with next', async () => {
+    const event = {
+      locals: { user: null, pb: createPBMock() as unknown as TypedPocketBase },
+      url: makeURL('/profile')
+    } as unknown as Parameters<typeof layoutLoad>[0]
+
+    await expect(layoutLoad(event)).rejects.toMatchObject({ status: 303, location: '/auth?reason=auth_required&next=%2Fprofile' })
+  })
+
+  it('redirects logged-in users away from /auth', async () => {
+    const user = makeUser({ id: 'u1', role: 'participant' }) as unknown as UsersResponse
+    const event = {
+      locals: { user, pb: createPBMock() as unknown as TypedPocketBase },
+      url: makeURL('/auth')
+    } as unknown as Parameters<typeof layoutLoad>[0]
+
+    await expect(layoutLoad(event)).rejects.toMatchObject({ status: 303, location: '/' })
+  })
+
+  it('returns user and reason when allowed', async () => {
+    const user = makeUser({ id: 'u2', role: 'participant' }) as unknown as UsersResponse
+    const event = {
+      locals: { user, pb: createPBMock() as unknown as TypedPocketBase },
+      url: makeURL('/profile', '?reason=account_deleted')
+    } as unknown as Parameters<typeof layoutLoad>[0]
+
+    const res = await layoutLoad(event)
+    expect(res).toMatchObject({ user: expect.objectContaining({ id: user.id }), reason: 'account_deleted' })
+  })
+})
+

--- a/app/src/routes/profile/+page.server.ts
+++ b/app/src/routes/profile/+page.server.ts
@@ -53,5 +53,22 @@ export const actions: Actions = {
 		logger.info('Logout', { userId: locals.user?.id ?? null })
 		locals.pb.authStore.clear()
 		throw redirect(303, '/auth')
+	},
+
+	deleteAccount: async ({ locals }) => {
+		if (!locals.user) {
+			throw redirect(303, '/auth')
+		}
+		const userId = locals.user.id
+		try {
+			await locals.pb.collection('users').delete(userId)
+		} catch {
+			logger.warn('Account deletion failed', { userId })
+			return fail(400, { message: 'Löschen fehlgeschlagen.', variant: 'error' })
+		}
+
+		logger.info('Account deleted', { userId })
+		locals.pb.authStore.clear()
+		throw redirect(303, '/auth?reason=account_deleted')
+		}
 	}
-}

--- a/app/src/routes/profile/+page.svelte
+++ b/app/src/routes/profile/+page.svelte
@@ -37,9 +37,23 @@
 					Künstlername ändern
 				</button>
 			</div>
-			<form method="post" action="?/logout" class="pt-2">
-				<button type="submit" class="btn-danger">Logout</button>
-			</form>
+			<div class="flex gap-3 pt-2">
+				<form method="post" action="?/logout">
+					<button type="submit" class="btn-danger">Logout</button>
+				</form>
+				<form
+					method="post"
+					action="?/deleteAccount"
+					onsubmit={(e) => {
+						e.preventDefault()
+						if (confirm('Bist du sicher? Dieser Vorgang kann nicht rückgängig gemacht werden.')) {
+							(e.currentTarget as HTMLFormElement).submit()
+						}
+					}}
+				>
+					<button type="submit" class="btn-danger">Konto löschen</button>
+				</form>
+			</div>
 		{/if}
 
 		{#if showPwd}

--- a/app/src/routes/profile/server.test.ts
+++ b/app/src/routes/profile/server.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest'
+import { actions } from './+page.server'
+import { createPBMock, makeUser } from '../../test/mocks'
+import type { TypedPocketBase, UsersResponse } from '$lib/pocketbase-types'
+
+function reqOf(fields: Record<string, unknown>): Request {
+  const request = {
+    formData: async () => ({
+      get: (k: string) => (k in fields ? (fields as Record<string, unknown>)[k] ?? null : null) as unknown as FormDataEntryValue | null
+    } as Pick<FormData, 'get'>)
+  }
+  return request as unknown as Request
+}
+
+describe('profile actions', () => {
+  it('changePassword redirects unauthenticated', async () => {
+    const event = {
+      request: reqOf({}),
+      locals: { user: null, pb: createPBMock() as unknown as TypedPocketBase }
+    } as unknown as Parameters<typeof actions.changePassword>[0]
+
+    await expect(actions.changePassword(event)).rejects.toMatchObject({ status: 303 })
+  })
+
+  it('changePassword validates mismatch', async () => {
+    const user = makeUser({ id: 'u1', role: 'participant' }) as unknown as UsersResponse
+    const pb = createPBMock({ users: { update: vi.fn(async () => ({})) } })
+
+    const event = {
+      request: reqOf({ password: 'a', passwordConfirm: 'b' }),
+      locals: { user, pb: pb as unknown as TypedPocketBase }
+    } as unknown as Parameters<typeof actions.changePassword>[0]
+
+    const res = (await actions.changePassword(event)) as unknown
+    const failRes = res as { status: number; data?: { message?: string } }
+    expect(failRes.status).toBe(400)
+    expect(failRes.data?.message).toBe('Passwörter stimmen nicht überein.')
+  })
+
+  it('changePassword updates and returns success', async () => {
+    const user = makeUser({ id: 'u2', role: 'participant' }) as unknown as UsersResponse
+    const update = vi.fn(async (id: string, data: Record<string, unknown>) => ({ id, ...data }))
+    const pb = createPBMock({ users: { update } })
+
+    const event = {
+      request: reqOf({ password: 'secret123', passwordConfirm: 'secret123' }),
+      locals: { user, pb: pb as unknown as TypedPocketBase }
+    } as unknown as Parameters<typeof actions.changePassword>[0]
+
+    const res = (await actions.changePassword(event)) as unknown
+    expect(update).toHaveBeenCalledWith(user.id, expect.objectContaining({ password: 'secret123', passwordConfirm: 'secret123' }))
+    expect(res).toMatchObject({ message: 'Passwort erfolgreich aktualisiert.', variant: 'success' })
+  })
+
+  it('changeArtist requires non-empty artistName', async () => {
+    const user = makeUser({ id: 'u3', role: 'participant' }) as unknown as UsersResponse
+    const pb = createPBMock({ users: { update: vi.fn(async () => ({})) } })
+
+    const event = {
+      request: reqOf({ artistName: '' }),
+      locals: { user, pb: pb as unknown as TypedPocketBase }
+    } as unknown as Parameters<typeof actions.changeArtist>[0]
+
+    const res = (await actions.changeArtist(event)) as unknown
+    const failRes = res as { status: number; data?: { message?: string } }
+    expect(failRes.status).toBe(400)
+    expect(failRes.data?.message).toBe('Bitte einen Künstlernamen eingeben.')
+  })
+
+  it('changeArtist updates and returns success', async () => {
+    const user = makeUser({ id: 'u4', role: 'participant' }) as unknown as UsersResponse
+    const update = vi.fn(async (id: string, data: Record<string, unknown>) => ({ id, ...data }))
+    const pb = createPBMock({ users: { update } })
+
+    const event = {
+      request: reqOf({ artistName: 'New Name' }),
+      locals: { user, pb: pb as unknown as TypedPocketBase }
+    } as unknown as Parameters<typeof actions.changeArtist>[0]
+
+    const res = (await actions.changeArtist(event)) as unknown
+    expect(update).toHaveBeenCalledWith(user.id, expect.objectContaining({ artistName: 'New Name' }))
+    expect(res).toMatchObject({ message: 'Künstlername gespeichert.', variant: 'success' })
+  })
+
+  it('logout clears auth and redirects', async () => {
+    const user = makeUser({ id: 'u5', role: 'participant' }) as unknown as UsersResponse
+    const pb = createPBMock()
+    const event = {
+      locals: { user, pb: pb as unknown as TypedPocketBase }
+    } as unknown as Parameters<typeof actions.logout>[0]
+
+    await expect(actions.logout(event)).rejects.toMatchObject({ status: 303 })
+    expect(pb.authStore.clear).toHaveBeenCalled()
+  })
+
+  it('deleteAccount deletes user, clears auth and redirects to /auth?reason=account_deleted', async () => {
+    const user = makeUser({ id: 'del1', role: 'participant' }) as unknown as UsersResponse
+    const del = vi.fn(async () => {})
+    const pb = createPBMock({ users: { delete: del } })
+
+    const event = {
+      locals: { user, pb: pb as unknown as TypedPocketBase }
+    } as unknown as Parameters<typeof actions.deleteAccount>[0]
+
+    await expect(actions.deleteAccount(event)).rejects.toMatchObject({ status: 303, location: '/auth?reason=account_deleted' })
+    expect(del).toHaveBeenCalledWith(user.id)
+    expect(pb.authStore.clear).toHaveBeenCalled()
+  })
+
+  it('deleteAccount returns failure on error without clearing auth', async () => {
+    const user = makeUser({ id: 'del2', role: 'participant' }) as unknown as UsersResponse
+    const del = vi.fn(async () => { throw new Error('db fail') })
+    const pb = createPBMock({ users: { delete: del } })
+
+    const event = {
+      locals: { user, pb: pb as unknown as TypedPocketBase }
+    } as unknown as Parameters<typeof actions.deleteAccount>[0]
+
+    const res = (await actions.deleteAccount(event)) as unknown
+    const failRes = res as { status: number; data?: { message?: string } }
+    expect(failRes.status).toBe(400)
+    expect(failRes.data?.message).toBe('Löschen fehlgeschlagen.')
+    expect(pb.authStore.clear).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/routes/song-choice/+page.svelte
+++ b/app/src/routes/song-choice/+page.svelte
@@ -49,7 +49,7 @@
 
 					<div class="flex items-center gap-3">
 						<button type="button" class="btn-brand" on:click={() => save(i)}>Speichern</button>
-						{#if songs[i]?.appleMusicSongId}
+						{#if songs[i]?.appleMusicSongId && songs[i].appleMusicSongId !== 'null'}
 							<button
 								type="button"
 								class="btn-apple"
@@ -192,6 +192,7 @@
 	function openApple(i: number) {
 		const id = songs[i]?.appleMusicSongId?.trim()
 		if (!id) return
+		if (id === 'manual') return
 		const storefront = 'de'
 		const url = `https://music.apple.com/${storefront}/song/${id}`
 		try {

--- a/app/src/routes/song-choice/api/+server.ts
+++ b/app/src/routes/song-choice/api/+server.ts
@@ -172,6 +172,10 @@ export const POST: RequestHandler = async ({ request, locals, fetch }) => {
             // If key/token is missing, skip validation gracefully
             if (verified.code === 'apple_token_missing') {
                 logger.warn('Apple verify skipped: token missing')
+                // Ensure required backend field is populated when skipping validation
+                if (!payload.appleMusicSongId) {
+                    ;(payload as SongChoicePayload).appleMusicSongId = 'null'
+                }
             } else {
                 logger.info('Apple verify failed', { code: verified.code })
                 const map: Record<string, { status: number; error: string }> = {
@@ -186,6 +190,11 @@ export const POST: RequestHandler = async ({ request, locals, fetch }) => {
             // Attach Apple Song ID from verification
             ;(payload as SongChoicePayload).appleMusicSongId = verified.appleMusicSongId
             logger.debug('Apple verify ok', { appleMusicSongId: verified.appleMusicSongId })
+        }
+    } else {
+        // Validation disabled by env flag; populate required field with placeholder
+        if (!payload.appleMusicSongId) {
+            ;(payload as SongChoicePayload).appleMusicSongId = 'null'
         }
     }
 

--- a/compose.env
+++ b/compose.env
@@ -3,13 +3,13 @@ APP_PORT=3000
 BACKEND_PORT=8090
 
 # Frontend public URL (set to your deployed domain in prod)
-ORIGIN=http://localhost:3000
+ORIGIN=http://localhost:${APP_PORT}
 
 # Frontend runtime
 NODE_ENV=production
 
 # Service-to-service URL inside the compose network
-PB_URL=http://backend:8080
+PB_URL=http://backend:${BACKEND_PORT}
 
 # Log settings
 LOG_LEVEL=info

--- a/compose.env
+++ b/compose.env
@@ -16,6 +16,10 @@ LOG_LEVEL=info
 LOG_FORMAT=pretty
 LOG_COLOR=true
 
+# Session / auth
+# Max cookie age in seconds (default 48h)
+SESSION_MAX_AGE=172800
+
 # Apple Music API configuration
 SONG_CHOICE_VALIDATE=true
 APPLE_MUSIC_KEY_ID=

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,7 @@ services:
     env_file:
       - compose.env
     ports:
-      - "${APP_PORT:-3000}:${APP_PORT:-3000}"
+      - "${APP_PORT:-5173}:${APP_PORT:-5173}"
     depends_on:
       - backend
     restart: unless-stopped


### PR DESCRIPTION
This pull request introduces several improvements and new features focused on authentication, session management, and user account handling. The most significant changes include enforcing session cookie expiration, validating authentication tokens with the backend, supporting account deletion for users, and adding comprehensive tests for authentication and profile actions. Additionally, user feedback is improved with more precise banner messages and error handling.

**Authentication and Session Management**
* Enforced session cookie expiration by introducing the `SESSION_MAX_AGE` environment variable, setting a default of 48 hours, and updating cookie handling to include a maximum age. The backend now validates and refreshes authentication tokens on each request, clearing them if invalid (e.g., after a database reset). (`README.md`, `app/src/hooks.server.ts`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R103-L100) [[3]](diffhunk://#diff-a91868c9aa8d6f83ad6950469c88266c3535f624ce4054383f05d2a61c42a187R11) [[4]](diffhunk://#diff-a91868c9aa8d6f83ad6950469c88266c3535f624ce4054383f05d2a61c42a187R27-R36) [[5]](diffhunk://#diff-a91868c9aa8d6f83ad6950469c88266c3535f624ce4054383f05d2a61c42a187L92-R105)
* Updated authentication banners to display specific messages when an account is deleted, enhancing user feedback during authentication flows. (`app/src/routes/auth/+page.svelte`)

**User Account Management**
* Added support for user account deletion: users can now delete their account from the profile page, which clears authentication and redirects them to the login page with a specific reason. (`app/src/routes/profile/+page.server.ts`, `app/src/routes/profile/+page.svelte`) [[1]](diffhunk://#diff-2d8d9b459213e45f51d668565ecc1c2e9148c47bec58f8a04e51979a9266ab9eR56-R72) [[2]](diffhunk://#diff-3d5b660383ccd7a0522907f41409e5eb376932c51721b69a1ac064f58510c960L40-R56)

**Testing and Reliability**
* Added comprehensive tests for authentication and profile actions, including login, signup, logout, password change, artist name change, and account deletion. These tests verify validation, redirects, and error handling for all major user flows. (`app/src/routes/auth/server.test.ts`, `app/src/routes/profile/server.test.ts`, `app/src/routes/layout.server.test.ts`, `app/src/hooks.server.test.ts`) [[1]](diffhunk://#diff-ce2daf1bd35ffe17de42ff553545810360b009f4769aa9536eb4904ad832983fR1-R94) [[2]](diffhunk://#diff-0016cd422cbbf053829216b126d3120f203ff09857b4677ee57ba54dc1d30befR1-R125) [[3]](diffhunk://#diff-bca1555b08e24c1b1ac5e46b04510f914fb34d1b6f39ee5d6fcf64fb28b0c000R1-R37) [[4]](diffhunk://#diff-157abe855314dadd01544c85c69ce0d24dd07abb04b626d64db3152b65eeae53R2-R74) [[5]](diffhunk://#diff-157abe855314dadd01544c85c69ce0d24dd07abb04b626d64db3152b65eeae53L63-R84) [[6]](diffhunk://#diff-157abe855314dadd01544c85c69ce0d24dd07abb04b626d64db3152b65eeae53L74-R111)

**Minor Improvements**
* Improved the song choice UI to hide the Apple Music button if the song ID is `'null'`, preventing confusing UI elements. (`app/src/routes/song-choice/+page.svelte`)
* Cleaned up development configuration by removing environment variables from `.vscode/launch.json`. (`.vscode/launch.json`)