### PR TITLE
Develop

### DIFF
--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -1,9 +1,7 @@
 <svelte:head>
 	<link rel="icon" href={favicon} />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Safari iOS Statusbar Farbe -->
-	<meta name="theme-color" content="#b82015" media="(prefers-color-scheme: light)">
-	<meta name="theme-color" content="#b82015" media="(prefers-color-scheme: dark)">
+	<meta name="viewport" content="width=device-width, user-scalable=no">
+	<meta name="theme-color" content="#b82015">
 </svelte:head>
 
 <div class="bg-halftone min-h-dvh bg-brand pt-3 text-white">


### PR DESCRIPTION
This pull request makes a minor update to the `<svelte:head>` section in `app/src/routes/+layout.svelte` to simplify and standardize the viewport and theme color meta tags.

- Simplified the `viewport` meta tag by removing the `maximum-scale` and `initial-scale` attributes, leaving only `width=device-width` and `user-scalable=no`.
- Consolidated the `theme-color` meta tag to a single entry, removing separate tags for light and dark color schemes.