### PR TITLE
Develop

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,9 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": [
         "run",
-        "dv"
+        "dv",
+        "--",
+        "--host"
       ],
       "preLaunchTask": "Start PocketBase",
       "console": "integratedTerminal",

--- a/app/src/app.css
+++ b/app/src/app.css
@@ -403,9 +403,9 @@
 	.overlay-backdrop {
 		position: absolute;
 		inset: 0;
-		background: var(--color-red-900);
+		background: rgba(184, 32, 21, 0.8);
 		opacity: 0.82;
-		backdrop-filter: blur(2px);
+		backdrop-filter: blur(1px);
 	}
 	.overlay-card {
 		position: absolute;

--- a/app/src/lib/components/Modal.svelte
+++ b/app/src/lib/components/Modal.svelte
@@ -5,7 +5,7 @@
 			<div class="overlay-body">
 				{@render children?.()}
 			</div>
-			<div class="overlay-foot">
+			<div>
 				{@render footer?.()}
 			</div>
 		</div>

--- a/app/src/lib/components/RoleSelection.svelte
+++ b/app/src/lib/components/RoleSelection.svelte
@@ -1,4 +1,4 @@
-<Modal open={visible} title="Rolle auswählen" onclose={onCancel}>
+<Modal open={visible} title="Rolle auswählen" onclose={() => {}}>
 	<div class="form-spacing">
 		<div class="content-spacing">
 			<h2 class="font-display text-responsive">Rolle auswählen</h2>
@@ -95,7 +95,6 @@
 		</div>
 
 		<div class="flex-responsive-actions">
-			<button type="button" class="btn-ghost" onclick={onCancel}>Abbrechen</button>
 			<button
 				type="button"
 				class="btn-brand"
@@ -120,7 +119,6 @@
 		currentParticipants?: number
 		currentJurors?: number
 		isLoading?: boolean
-		onCancel?: () => void
 		onSubmit?: (role: UserRole) => void
 	}
 
@@ -131,7 +129,6 @@
 		currentParticipants = 0,
 		currentJurors = 0,
 		isLoading = false,
-		onCancel,
 		onSubmit
 	}: Props = $props()
 

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -57,50 +57,51 @@
 				</table>
 			</div>
 		</div>
-
-		<div class="panel panel-accent overflow-hidden p-0">
-			<div class="table-header-border padding-responsive py-3">
-				<div class="font-semibold">Alle Spectators</div>
-			</div>
-			<div class="table-container">
-				<table class="w-full text-sm">
-					<thead>
-						<tr class="table-header">
-							<th class="table-cell">Name</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each data.spectators as u (u.id || u.name)}
-							<tr class="table-row-border">
-								<td class="table-cell">{u.name}</td>
+		{#if showRoleSelection === false}
+			<div class="panel panel-accent overflow-hidden p-0">
+				<div class="table-header-border padding-responsive py-3">
+					<div class="font-semibold">Alle Spectators</div>
+				</div>
+				<div class="table-container">
+					<table class="w-full text-sm">
+						<thead>
+							<tr class="table-header">
+								<th class="table-cell">Name</th>
 							</tr>
-						{/each}
-					</tbody>
-				</table>
+						</thead>
+						<tbody>
+							{#each data.spectators as u (u.id || u.name)}
+								<tr class="table-row-border">
+									<td class="table-cell">{u.name}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
 			</div>
-		</div>
 
-		<div class="panel panel-accent overflow-hidden p-0">
-			<div class="table-header-border padding-responsive py-3">
-				<div class="font-semibold">Alle Juroren</div>
-			</div>
-			<div class="table-container">
-				<table class="w-full text-sm">
-					<thead>
-						<tr class="table-header">
-							<th class="table-cell">Name</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each data.jurors as u (u.id || u.name)}
-							<tr class="table-row-border">
-								<td class="table-cell">{u.name}</td>
+			<div class="panel panel-accent overflow-hidden p-0">
+				<div class="table-header-border padding-responsive py-3">
+					<div class="font-semibold">Alle Juroren</div>
+				</div>
+				<div class="table-container">
+					<table class="w-full text-sm">
+						<thead>
+							<tr class="table-header">
+								<th class="table-cell">Name</th>
 							</tr>
-						{/each}
-					</tbody>
-				</table>
+						</thead>
+						<tbody>
+							{#each data.jurors as u (u.id || u.name)}
+								<tr class="table-row-border">
+									<td class="table-cell">{u.name}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
 			</div>
-		</div>
+		{/if}
 	{/if}
 </section>
 
@@ -112,7 +113,6 @@
 	currentParticipants={data.currentParticipants}
 	currentJurors={data.currentJurors}
 	isLoading={roleSelectionLoading}
-	onCancel={closeRoleSelection}
 	onSubmit={handleRoleSubmit}
 />
 
@@ -138,13 +138,6 @@
 			showRoleSelection = true
 		}
 	})
-
-	function closeRoleSelection() {
-		if (!data.needsRoleSelection) {
-			showRoleSelection = false
-		}
-		// If user needs role selection, don't allow closing without selection
-	}
 
 	async function handleRoleSubmit(role: UserRole) {
 		if (roleSelectionLoading) return

--- a/app/src/routes/admin/+page.server.ts
+++ b/app/src/routes/admin/+page.server.ts
@@ -1,0 +1,19 @@
+import type { PageServerLoad } from './$types';
+import type { CompetitionStateResponse, UsersResponse } from '$lib/pocketbase-types'
+
+type AdminResponse = {
+    state: CompetitionStateResponse | null,
+    activeParticipant: UsersResponse | null
+};
+
+export const load = (async ({fetch}) => {
+    const res = await fetch('/admin/api');
+    if (!res.ok) {
+        throw new Error('Failed to fetch admin state');
+    }
+    const data: AdminResponse = await res.json();
+    return {
+        competitionState: data.state,
+        activeUser: data.activeParticipant
+    };
+}) satisfies PageServerLoad;

--- a/app/src/routes/admin/+page.server.ts
+++ b/app/src/routes/admin/+page.server.ts
@@ -1,19 +1,19 @@
-import type { PageServerLoad } from './$types';
+import type { PageServerLoad } from './$types'
 import type { CompetitionStateResponse, UsersResponse } from '$lib/pocketbase-types'
 
 type AdminResponse = {
-    state: CompetitionStateResponse | null,
-    activeParticipant: UsersResponse | null
-};
+	state: CompetitionStateResponse | null
+	activeParticipant: UsersResponse | null
+}
 
-export const load = (async ({fetch}) => {
-    const res = await fetch('/admin/api');
-    if (!res.ok) {
-        throw new Error('Failed to fetch admin state');
-    }
-    const data: AdminResponse = await res.json();
-    return {
-        competitionState: data.state,
-        activeUser: data.activeParticipant
-    };
-}) satisfies PageServerLoad;
+export const load = (async ({ fetch }) => {
+	const res = await fetch('/admin/api')
+	if (!res.ok) {
+		throw new Error('Failed to fetch admin state')
+	}
+	const data: AdminResponse = await res.json()
+	return {
+		competitionState: data.state,
+		activeUser: data.activeParticipant
+	}
+}) satisfies PageServerLoad

--- a/app/src/routes/admin/+page.svelte
+++ b/app/src/routes/admin/+page.svelte
@@ -133,7 +133,7 @@
 
 <script lang="ts">
 	import type { CompetitionStateResponse, UsersResponse } from '$lib/pocketbase-types'
-	let { data } = $props();
+	let { data } = $props()
 
 	let competitionState: CompetitionStateResponse | null = $state(data?.competitionState)
 	let active: UsersResponse | null = $state(data?.activeUser)

--- a/app/src/routes/profile/+page.server.ts
+++ b/app/src/routes/profile/+page.server.ts
@@ -159,7 +159,7 @@ export const actions: Actions = {
 
 				// Count current users with this role (excluding current user)
 				const users = (await locals.pb.collection('users').getFullList()) as UsersResponse[]
-				const currentCount = users.filter((u) => u.role === role && u.id !== locals.user.id).length
+				const currentCount = users.filter((u) => u.role === role && u.id !== locals.user?.id).length
 
 				if (role === 'participant' && currentCount >= maxParticipants) {
 					return fail(400, { message: 'Maximale Anzahl Teilnehmer erreicht.', variant: 'error' })

--- a/app/src/routes/profile/+page.svelte
+++ b/app/src/routes/profile/+page.svelte
@@ -66,7 +66,9 @@
 						}
 					}}
 				>
-					<button type="submit" class="btn-danger">Konto löschen</button>
+					{#if user?.role !== 'admin'}
+						<button type="submit" class="btn-danger">Konto löschen</button>
+					{/if}
 				</form>
 			</div>
 		{/if}

--- a/app/src/routes/rating/state/+server.ts
+++ b/app/src/routes/rating/state/+server.ts
@@ -15,7 +15,9 @@ export const GET: RequestHandler = async ({ locals }) => {
 	}
 
 	try {
-		const list = (await locals.pb.collection(COLLECTION).getList(1, 1)) as import('pocketbase').ListResult<CompetitionStateResponse>
+		const list = (await locals.pb
+			.collection(COLLECTION)
+			.getList(1, 1)) as import('pocketbase').ListResult<CompetitionStateResponse>
 		const rec = list.items[0]
 		if (!rec) {
 			logger.warn('CompetitionState not found, returning defaults')

--- a/app/src/routes/rating/state/+server.ts
+++ b/app/src/routes/rating/state/+server.ts
@@ -15,9 +15,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 	}
 
 	try {
-		const list = (await locals.pb.collection(COLLECTION).getList(1, 1, {
-			sort: '-updated'
-		})) as import('pocketbase').ListResult<CompetitionStateResponse>
+		const list = (await locals.pb.collection(COLLECTION).getList(1, 1)) as import('pocketbase').ListResult<CompetitionStateResponse>
 		const rec = list.items[0]
 		if (!rec) {
 			logger.warn('CompetitionState not found, returning defaults')

--- a/app/tests/integration/api/role.test.ts
+++ b/app/tests/integration/api/role.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { POST } from '../../../src/routes/api/role/+server'
-import { createPBMock, makeUser, makeSettings } from '../../utils/mocks'
-
+import { createPBMock, makeUser, makeSettings, createRequestEvent } from '../../utils/mocks'
 type TestLocals = {
 	pb: ReturnType<typeof createPBMock>
 	user: ReturnType<typeof makeUser> | null
@@ -26,8 +25,8 @@ describe('/api/role endpoint', () => {
 			settings: {
 				getFullList: () =>
 					Promise.resolve([
-						makeSettings('maxParticipantCount', 5),
-						makeSettings('maxJurorCount', 3)
+						makeSettings({ maxParticipantCount: 5 }),
+						makeSettings({ maxJurorCount: 3 })
 					])
 			}
 		})
@@ -46,7 +45,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'participant' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(401)
 		})
 	})
@@ -59,7 +60,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'participant' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(200)
 		})
 
@@ -70,7 +73,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'spectator' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(200)
 		})
 
@@ -81,7 +86,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'juror' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(200)
 		})
 
@@ -92,7 +99,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'admin' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(403)
 
 			const data = await response.json()
@@ -106,7 +115,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'invalid' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(400)
 
 			const data = await response.json()
@@ -120,7 +131,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({})
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(400)
 		})
 	})
@@ -157,7 +170,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'participant' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(400)
 
 			const data = await response.json()
@@ -193,7 +208,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'juror' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(400)
 
 			const data = await response.json()
@@ -207,7 +224,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'spectator' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(200)
 		})
 	})
@@ -222,7 +241,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'spectator' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(400)
 
 			const data = await response.json()
@@ -248,7 +269,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'participant' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(200)
 		})
 	})
@@ -261,7 +284,9 @@ describe('/api/role endpoint', () => {
 				body: 'invalid json'
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(400)
 
 			const data = await response.json()
@@ -286,7 +311,9 @@ describe('/api/role endpoint', () => {
 				body: JSON.stringify({ role: 'spectator' })
 			})
 
-			const response = await POST({ locals, request } as { locals: TestLocals; request: Request })
+			const response = await POST(
+				createRequestEvent(locals, request) as unknown as Parameters<typeof POST>[0]
+			)
 			expect(response.status).toBe(500)
 
 			const data = await response.json()

--- a/app/tests/unit/lib/server/appleToken.test.ts
+++ b/app/tests/unit/lib/server/appleToken.test.ts
@@ -15,11 +15,58 @@ vi.mock('$lib/server/logger', () => ({
 
 describe('Apple Music Token', () => {
 	const mockSign = vi.fn()
-	const mockCreateSign = vi.fn(() => ({
-		update: vi.fn(),
-		end: vi.fn(),
-		sign: mockSign
-	}))
+	const mockCreateSign = vi.fn(() => {
+		const mockSignInstance = {
+			update: vi.fn(),
+			end: vi.fn(),
+			sign: mockSign,
+			// Add required stream properties
+			writable: true,
+			writableEnded: false,
+			writableFinished: false,
+			writableHighWaterMark: 16384,
+			writableLength: 0,
+			writableObjectMode: false,
+			writableCorked: 0,
+			writableAborted: false,
+			writableNeedDrain: false,
+			destroyed: false,
+			closed: false,
+			errored: null,
+			// Add stream methods as mocks
+			write: vi.fn(),
+			cork: vi.fn(),
+			uncork: vi.fn(),
+			setDefaultEncoding: vi.fn(),
+			destroy: vi.fn(),
+			_write: vi.fn(),
+			_writev: vi.fn(),
+			_destroy: vi.fn(),
+			_final: vi.fn(),
+			pipe: vi.fn(),
+			unpipe: vi.fn(),
+			on: vi.fn(),
+			off: vi.fn(),
+			emit: vi.fn(),
+			once: vi.fn(),
+			removeListener: vi.fn(),
+			removeAllListeners: vi.fn(),
+			setMaxListeners: vi.fn(),
+			getMaxListeners: vi.fn(),
+			listeners: vi.fn(),
+			rawListeners: vi.fn(),
+			listenerCount: vi.fn(),
+			prependListener: vi.fn(),
+			prependOnceListener: vi.fn(),
+			eventNames: vi.fn(),
+			addListener: vi.fn(),
+			[Symbol.asyncIterator]: vi.fn(),
+			[Symbol.iterator]: vi.fn(),
+			[Symbol.asyncDispose]: vi.fn(),
+			compose: vi.fn()
+		}
+		return mockSignInstance
+	})
 
 	beforeEach(() => {
 		vi.clearAllMocks()

--- a/app/tests/unit/utils/validation.test.ts
+++ b/app/tests/unit/utils/validation.test.ts
@@ -204,7 +204,12 @@ describe('Validation Utils', () => {
 				errors.push('Invalid user ID')
 			}
 
-			if (!Number.isInteger(data.round) || data.round < 1 || data.round > 5) {
+			if (
+				typeof data.round !== 'number' ||
+				!Number.isInteger(data.round) ||
+				data.round < 1 ||
+				data.round > 5
+			) {
 				errors.push('Invalid round number')
 			}
 

--- a/app/tests/utils/mocks.ts
+++ b/app/tests/utils/mocks.ts
@@ -119,3 +119,32 @@ export const mockSettings = makeSettings({
 	maxParticipantCount: 8,
 	maxJurorCount: 5
 })
+
+export function createRequestEvent<T = Record<string, unknown>>(
+	locals: T,
+	request: Request,
+	params: Record<string, string> = {}
+) {
+	return {
+		locals,
+		request,
+		params,
+		cookies: {
+			get: vi.fn(),
+			getAll: vi.fn(),
+			set: vi.fn(),
+			delete: vi.fn(),
+			serialize: vi.fn()
+		},
+		fetch: vi.fn(fetch),
+		getClientAddress: vi.fn(() => '127.0.0.1'),
+		platform: undefined,
+		route: { id: null },
+		setHeaders: vi.fn(),
+		url: new URL(request.url),
+		isDataRequest: false,
+		isSubRequest: false,
+		tracing: undefined,
+		isRemoteRequest: false
+	}
+}


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the admin panel, role selection flow, and supporting backend logic. The main focus is on improving state management in the admin panel, refactoring the role selection modal to simplify its interface, and enhancing error handling and test coverage for role assignment. Below are the most important changes grouped by theme:

**Admin Panel State Management and Refactoring**
* Refactored the admin panel (`+page.svelte`) to use a unified `competitionState` object from the server, replacing multiple local state variables and simplifying logic for displaying and updating competition status. All references to the previous `state` and `active` variables have been updated. [[1]](diffhunk://#diff-bfc6b53edf521b86d069dc07187796fd353c71114df5bd1df32acd8be57af01bL21-R64) [[2]](diffhunk://#diff-bfc6b53edf521b86d069dc07187796fd353c71114df5bd1df32acd8be57af01bL135-R142) [[3]](diffhunk://#diff-bfc6b53edf521b86d069dc07187796fd353c71114df5bd1df32acd8be57af01bL171-R153) [[4]](diffhunk://#diff-bfc6b53edf521b86d069dc07187796fd353c71114df5bd1df32acd8be57af01bL205-R189) [[5]](diffhunk://#diff-bfc6b53edf521b86d069dc07187796fd353c71114df5bd1df32acd8be57af01bL236-R217) [[6]](diffhunk://#diff-bfc6b53edf521b86d069dc07187796fd353c71114df5bd1df32acd8be57af01bL259-R240) [[7]](diffhunk://#diff-bfc6b53edf521b86d069dc07187796fd353c71114df5bd1df32acd8be57af01bL284-R265) [[8]](diffhunk://#diff-bfc6b53edf521b86d069dc07187796fd353c71114df5bd1df32acd8be57af01bL77-R83)
* Added a server-side load function (`+page.server.ts`) for the admin panel to fetch and provide the competition state and active participant.

**Role Selection Modal Refactor**
* Removed the `onCancel` prop and related logic from `RoleSelection.svelte`, making the modal non-dismissible when role selection is required. The cancel button has been removed from the UI, and the modal now always stays open until a role is submitted. [[1]](diffhunk://#diff-dad222df4e87bda3577da6871535a85eb4e5b519fca2b4fc3a938486cb242b1dL1-R1) [[2]](diffhunk://#diff-dad222df4e87bda3577da6871535a85eb4e5b519fca2b4fc3a938486cb242b1dL98) [[3]](diffhunk://#diff-dad222df4e87bda3577da6871535a85eb4e5b519fca2b4fc3a938486cb242b1dL123) [[4]](diffhunk://#diff-dad222df4e87bda3577da6871535a85eb4e5b519fca2b4fc3a938486cb242b1dL134) [[5]](diffhunk://#diff-4031024d1d88e1ec0f03b3cca6c99038be6e25d627055fc203db7edb25d1d0bcL115) [[6]](diffhunk://#diff-4031024d1d88e1ec0f03b3cca6c99038be6e25d627055fc203db7edb25d1d0bcL142-L148)
* Updated modal markup and styling to accommodate these changes and ensure consistent rendering.

**Backend and Error Handling Improvements**
* Improved error handling in the admin API (`activate_rating_phase`): when marking a participant as having sung this round fails due to missing or inaccessible records, the active participant pointer is cleared to avoid stale state.
* Updated the rating state API to remove unnecessary sorting when fetching the latest competition state.

**Testing and Utility Enhancements**
* Refactored integration tests for the `/api/role` endpoint to use a new `createRequestEvent` utility, improving test clarity and coverage for various role assignment scenarios. Also updated test mocks for settings. [[1]](diffhunk://#diff-25f17a4d9f6d3477c1878a3685d694878dbedaad97e2bf8c0c5b485bcb6f55f3L3-R3) [[2]](diffhunk://#diff-25f17a4d9f6d3477c1878a3685d694878dbedaad97e2bf8c0c5b485bcb6f55f3L29-R29) [[3]](diffhunk://#diff-25f17a4d9f6d3477c1878a3685d694878dbedaad97e2bf8c0c5b485bcb6f55f3L49-R50) [[4]](diffhunk://#diff-25f17a4d9f6d3477c1878a3685d694878dbedaad97e2bf8c0c5b485bcb6f55f3L62-R65) [[5]](diffhunk://#diff-25f17a4d9f6d3477c1878a3685d694878dbedaad97e2bf8c0c5b485bcb6f55f3L73-R78) [[6]](diffhunk://#diff-25f17a4d9f6d3477c1878a3685d694878dbedaad97e2bf8c0c5b485bcb6f55f3L84-R91) [[7]](diffhunk://#diff-25f17a4d9f6d3477c1878a3685d694878dbedaad97e2bf8c0c5b485bcb6f55f3L95-R104) [[8]](diffhunk://#diff-25f17a4d9f6d3477c1878a3685d694878dbedaad97e2bf8c0c5b485bcb6f55f3L109-R120)

**UI and Miscellaneous Updates**
* Minor UI tweaks: adjusted overlay backdrop color and blur, and made the "delete account" button conditional for non-admin users in the profile page. [[1]](diffhunk://#diff-563fe3d27b9de75a64e1690e1f2d92d0241bd212798febee36d06f1c6528779dL406-R408) [[2]](diffhunk://#diff-3d5b660383ccd7a0522907f41409e5eb376932c51721b69a1ac064f58510c960R69-R71)
* Updated VSCode launch configuration to support passing the `--host` flag for development server.
* Fixed participant count calculation in profile server logic to handle cases where the user may be null.